### PR TITLE
main: Fix broken link to 'important places'

### DIFF
--- a/docs/distrodiy.md
+++ b/docs/distrodiy.md
@@ -7,7 +7,7 @@ If you don't trust people on the internet (and rightfully so), you may want to p
 > [!WARNING]
 > This is meant for advanced users ONLY.
 > 
-> Some things may not work properly. If you encounter issues, chat on the [Discords](/revisions#important-places).
+> Some things may not work properly. If you encounter issues, chat on the [Discords](/information#important-places).
 
 ## Preamble - why is this necessary?
 The community, as we've established before, is divided: there's the french (that nobody understands), there's people who want to work for real, but in the end none of them work together. So, even after almost 10 years, we still haven't seen these patches merged onto the original projects. Bruh.

--- a/docs/files.md
+++ b/docs/files.md
@@ -49,7 +49,7 @@ If you have issues, remember to check the [Issues page](/issues).
 ### More kernels
 If you really want to try other and older kernels, even though it's highly discouraged, you can go to the [Legacy and other Kernels](legacy#kernels) section.
 
-If you want more kernels or help, ask out the [Discord servers](/revisions#important-places).
+If you want more kernels or help, ask out the [Discord servers](/information#important-places).
 
 ## Initramfs
 This is the rescue shell that boots your Linux installer/installation. I'll be using one only, and it's going to be the one that was originally created for PSXITARCH, a distro based on Arch made by the PS3ITA Forums. [Here it is](https://github.com/DionKill/ps4-linux-tutorial/blob/main/PS4%20Linux/initramfs.zip). [Source (not really)](https://bitbucket.org/piotrkarbowski/better-initramfs/src/master/).

--- a/docs/it/distrodiy.md
+++ b/docs/it/distrodiy.md
@@ -7,7 +7,7 @@ If you don't trust people on the internet (and rightfully so), you may want to p
 > [!WARNING]
 > This is meant for advanced users ONLY.
 > 
-> Some things may not work properly. If you encounter issues, chat on the [Discords](/revisions#important-places).
+> Some things may not work properly. If you encounter issues, chat on the [Discords](/information#important-places).
 
 ## Preamble - why is this necessary?
 The community, as we've established before, is divided: there's the french (that nobody understands), there's people who want to work for real, but in the end none of them work together. So, even after almost 10 years, we still haven't seen these patches merged onto the original projects. Bruh.

--- a/docs/it/files.md
+++ b/docs/it/files.md
@@ -49,7 +49,7 @@ If you have issues, remember to check the [Issues page](/issues).
 ### More kernels
 If you really want to try other and older kernels, even though it's highly discouraged, you can go to the [Legacy and other Kernels](legacy#kernels) section.
 
-If you want more kernels or help, ask out the [Discord servers](/revisions#important-places).
+If you want more kernels or help, ask out the [Discord servers](/information#important-places).
 
 ## Initramfs
 This is the rescue shell that boots your Linux installer/installation. I'll be using one only, and it's going to be the one that was originally created for PSXITARCH, a distro based on Arch made by the PS3ITA Forums. [Here it is](https://github.com/DionKill/ps4-linux-tutorial/blob/main/PS4%20Linux/initramfs.zip). [Source (not really)](https://bitbucket.org/piotrkarbowski/better-initramfs/src/master/).


### PR DESCRIPTION
Replace '/revisions#important-places'
with '/information#important-places'

Fixes link to Discord servers' section from different pages. Files changed:
 docs/distrodiy.md
 docs/files.md
 docs/it/distrodiy.md
 docs/it/files.md