### PR TITLE
main:  Fix wrong kernel info & update links in files.md

### DIFF
--- a/docs/files.md
+++ b/docs/files.md
@@ -20,19 +20,21 @@ If all you care about is squeezing as much performance as possible out of the PS
 ### Vanilla kernels
 These are normal linux kernels with additional patches to make them work properly on the PS4. 
 
-| Kernel Download                                                                                                                                                         | Source code                                        | Compatible Southbridges   | Extra info                                       |
+| Kernel Download                                                                                                                                                         | Compatible Southbridges                                         | Source Code   | Extra info                                       |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- | ------------------------- | ------------------------------------------------ |
-| [6.15.4](https://github.com/feeRnt/ps4-linux-12xx/releases/tag/v6.15.4__crashnt-3)<br>(Recommended)                                                                     | [GitHub](https://github.com/feeRnt/ps4-linux-12xx) | Aeolia & Belize ONLY      | Specific blackscreen-fix releases. Recommended.  |
-| [5.15.x](https://github.com/feeRnt/ps4-linux-12xx/releases/tag/v5.15.15__3.5.0)<br>[5.4.x](https://github.com/feeRnt/ps4-linux-12xx/releases/tag/v5.4.247__baikal_mt76) | [GitHub](https://github.com/feeRnt/ps4-linux-12xx) | All (5.4 only for Baikal) | Check Actions section if the releases don't work |
+| [6.15.4](https://github.com/feeRnt/ps4-linux-12xx/releases/tag/v6.15.4__crashnt-3)<br>(Recommended) | Aeolia &<br>Belize | [GitHub](https://github.com/feeRnt/ps4-linux-12xx/) | Specific blackscreen-fix releases. Recommended.  |
+| [5.4.247](https://github.com/feeRnt/ps4-linux-12xx/releases/tag/v5.4.247__baikal_mt76) | Baikal | [GitHub](https://github.com/feeRnt/ps4-linux-12xx/) | Check Actions section if the releases don't work |
+| [5.15.15](https://github.com/feeRnt/ps4-linux-12xx/releases/tag/v5.15.15__3.5.0) <br> Belize Ver. | Belize | [GitHub](https://github.com/feeRnt/ps4-linux-12xx/) | Might provide better performance than 6.15.4.
+| [5.15.15](https://github.com/feeRnt/ps4-linux-12xx/releases/tag/v5.15.15__1.0.0) <br>Aeolia Ver. | Aeolia | [GitHub](https://github.com/feeRnt/ps4-linux-12xx/) | NOT RECOMMENDED.<br> Has half broken SATA/Bluray driver. Use for testing only.
 
 ::: details Performance kernels
 ### "Performance patched" kernels
 These kernels are compiled using additional optimizations. Don't expect a 3x improvement in performance, they just add features and make the system a bit more responsive.
 
-| Kernel                                                           | Source code | Compatible Southbridges | Extra info                                                                                                              |
+| Kernel Download                                                          | Compatible Southbridges | Source Code | Extra info                                                                                                              |
 | ---------------------------------------------------------------- | ----------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| [6.15 and 5.15](https://www.youtube.com/watch?v=zVzHzJT7dHk)     | N/A         | All                     | FullLTO, 120Hz support, 4K for PS4 Pro. You need to download the whole archive and pick one for your needs.<br>By saya. |
-| [6.15.4](https://mega.nz/folder/N0QjHSBT#609IHevkWEW0vnTCFW-Rhw) | N/A?        | Aeolia<br>Belize        | ZRAM, CachyOS patches, KVM and more. <br>By triki1.                                                                     |
+| [6.15,<br>5.15 and<br> 5.4](https://www.youtube.com/watch?v=zVzHzJT7dHk)     |   All     |  N/A                      | FullLTO, 120Hz support, 4K for PS4 Pro. You need to download the whole archive and pick one for your needs.<br>By saya. |
+| [6.15.4](https://mega.nz/folder/N0QjHSBT#609IHevkWEW0vnTCFW-Rhw) |  Aeolia &<br>Belize      | N/A?         | ZRAM, CachyOS patches, KVM and more. <br>By triki1.                                                                     |
 
 :::
 
@@ -52,7 +54,7 @@ Honestly there's a neptillion distros... Choose one that you may like, or distro
 
 | Distro                                                                                               | Base                            | Port credits                                                              | Info                                                                                |
 | ---------------------------------------------------------------------------------------------------- | ------------------------------- | ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| [CachyOS](https://mega.nz/file/RyUVQARB#HZD49XXac_v2CYKD4Oqa7Tg1aiZ7ltH_cnDxixw9JjY)                 | Arch                            | [Elokuba (Qba)](https://www.youtube.com/channel/UCU-eXjZ7Ud0k2wC_14mqdOw) | "Final Fantasy v2" version. It has nothing to do with FF.                           |
+| [CachyOS](https://mega.nz/file/RyUVQARB#HZD49XXac_v2CYKD4Oqa7Tg1aiZ7ltH_cnDxixw9JjY)                 | Arch                            | [Elokuba (Qba)](https://www.youtube.com/channel/UCU-eXjZ7Ud0k2wC_14mqdOw) | "Final Fantasy v2" version. It has nothing to do with FF. Mere fantasy.                          |
 | [EndeavourOS](https://ps4linux.com/forums/d/386-endeavouros-gaming-rebirth)                          | Arch                            | [Elokuba (Qba)](https://www.youtube.com/channel/UCU-eXjZ7Ud0k2wC_14mqdOw) | Arch based distro that's nice to use and easy to maintain                           |
 | [Manjaro](https://ps4linux.com/forums/d/342-manjaro-from-scratch)                                    | Arch                            | [Elokuba (Qba)](https://www.youtube.com/channel/UCU-eXjZ7Ud0k2wC_14mqdOw) | A Manjaro KDE distro                                                                |
 | [Garuda](https://ps4linux.com/forums/d/415-garuda-dr460nized-gaming-v2/2)                            | Arch                            | [Elokuba (Qba)](https://www.youtube.com/channel/UCU-eXjZ7Ud0k2wC_14mqdOw) | "Gaming focused" distro (not really)                                                |

--- a/docs/it/files.md
+++ b/docs/it/files.md
@@ -9,76 +9,64 @@ This is the section for recommended kernels. There are both vanilla kernels and 
 
 [Credits for all of these kernels](/ending#credits).
 
-::: details "Which one to pick" or "I have issues"
-Hard to say as there's a neptillion of them, but I'd recommend starting from the top (mind the Southbridge) and going down until you can find one that works.
+::: details Read this if you're confused!
+### Do kernel versions matter?
+Yes, but only for Baikal, as it has been stuck on 5.4 for a while and can't use modern GPU drivers anymore. For the rest, it doesn't matter.
 
-If all you care about is squeezing as much performance as possible out of the PS4 (you do) try the performance kernel section first. Those have patches to make the system more responsive (in theory).
-
-If you still have issues, write on the forums or join the Discords. Links are at the start of the guide.
+### What about more performance!!!
+If all you care about is squeezing as much performance as possible out of the PS4 (you do) try the performance kernel section first. Those have patches to make the system more responsive.
 :::
 
-::: details Do newer kernels matter?
-For Baikal, yes indeed. Modern versions of Mesa require modern versions of LibDRM which needs newer versions of the kernels.
-
-But apart from that, not really. New features are mostly added for newer processors and devices, though there are cool things like better performance on specific scenarios and native drivers for things like PS4's controllers, but as long as you have a 5.x+ kernel your experience should be mostly the same, as those support Vulkan.
-:::
 ### Vanilla kernels
 These are normal linux kernels with additional patches to make them work properly on the PS4. 
 
-| Kernel                                                                                                                                                                                   | Source and Download                                 | Compatible Southbridges    | Extra info                                          |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | -------------------------- | --------------------------------------------------- |
-| [6.15.4](https://github.com/feeRnt/ps4-linux-12xx/releases/tag/v6.15.4__crashnt-3)                                                                                                       | [GitHub](https://github.com/feeRnt/ps4-linux-12xx)  | Aeolia<br>Belize           | Specific blackscreen-fix release                    |
-| [6.15.x](https://github.com/feeRnt/ps4-linux-12xx/releases)<br>[5.15.x](https://github.com/feeRnt/ps4-linux-12xx/releases)<br>[5.4.x](https://github.com/feeRnt/ps4-linux-12xx/releases) | [GitHub](https://github.com/feeRnt/ps4-linux-12xx)  | All                        | Check Actions section if the releases don't work    |
-| 6.x<br>5.x<br>4.x                                                                                                                                                                        | [tux4orbis' Discord](https://discord.gg/s6DMgxxqQb) | All (Baikal in particular) | These kernels are in beta<br>Recommended for Baikal |
+| Kernel Download                                                                                                                                                         | Compatible Southbridges                                         | Source Code   | Extra info                                       |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- | ------------------------- | ------------------------------------------------ |
+| [6.15.4](https://github.com/feeRnt/ps4-linux-12xx/releases/tag/v6.15.4__crashnt-3)<br>(Recommended) | Aeolia &<br>Belize | [GitHub](https://github.com/feeRnt/ps4-linux-12xx/) | Specific blackscreen-fix releases. Recommended.  |
+| [5.4.247](https://github.com/feeRnt/ps4-linux-12xx/releases/tag/v5.4.247__baikal_mt76) | Baikal | [GitHub](https://github.com/feeRnt/ps4-linux-12xx/) | Check Actions section if the releases don't work |
+| [5.15.15](https://github.com/feeRnt/ps4-linux-12xx/releases/tag/v5.15.15__3.5.0) <br> Belize Ver. | Belize | [GitHub](https://github.com/feeRnt/ps4-linux-12xx/) | Might provide better performance than 6.15.4.
+| [5.15.15](https://github.com/feeRnt/ps4-linux-12xx/releases/tag/v5.15.15__1.0.0) <br>Aeolia Ver. | Aeolia | [GitHub](https://github.com/feeRnt/ps4-linux-12xx/) | NOT RECOMMENDED.<br> Has half broken SATA/Bluray driver. Use for testing only.
 
+::: details Performance kernels
 ### "Performance patched" kernels
-These kernels are compiled using additional optimizations. Some of them use LTO, some also add CachyOS's patches, and some others also add ZRAM or additional features.
+These kernels are compiled using additional optimizations. Don't expect a 3x improvement in performance, they just add features and make the system a bit more responsive.
 
-Don't expect a 3x improvement in performance, they just add features and make the system a bit more responsive.
+| Kernel Download                                                          | Compatible Southbridges | Source Code | Extra info                                                                                                              |
+| ---------------------------------------------------------------- | ----------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| [6.15,<br>5.15 and<br> 5.4](https://www.youtube.com/watch?v=zVzHzJT7dHk)     |   All     |  N/A                      | FullLTO, 120Hz support, 4K for PS4 Pro. You need to download the whole archive and pick one for your needs.<br>By saya. |
+| [6.15.4](https://mega.nz/folder/N0QjHSBT#609IHevkWEW0vnTCFW-Rhw) |  Aeolia &<br>Belize      | N/A?         | ZRAM, CachyOS patches, KVM and more. <br>By triki1.                                                                     |
 
-| Kernel                                                                     | Source                   | Compatible Southbridges | Extra info                                                                                                  |
-| -------------------------------------------------------------------------- | ------------------------ | ----------------------- | ----------------------------------------------------------------------------------------------------------- |
-| [5.x and 6.15](https://www.youtube.com/watch?v=zVzHzJT7dHk) by saya        | feeRnt's and crashniels' | All                     | FullLTO, 120Hz support, 4K for PS4 Pro. You need to download the whole archive and pick one for your needs. |
-| [6.15.4](https://mega.nz/folder/N0QjHSBT#609IHevkWEW0vnTCFW-Rhw) by triki1 | feeRnt's and crashniels' | Aeolia<br>Belize        | ZRAM, CachyOS patches, KVM and more                                                                         |
+:::
 
-
-### Specific kernel problems
-Before continuing, I want to mention that there can be many issues with kernel and distro combinations.
-
-If you have issues, remember to check the [Issues page](/issues).
-### More kernels
-If you really want to try other and older kernels, even though it's highly discouraged, you can go to the [Legacy and other Kernels](legacy#kernels) section.
-
-If you want more kernels or help, ask out the [Discord servers](/information#important-places).
+If you have issues, remember to check the [Issues page](/issues). If you want more help, check out [Discord servers](/information#important-places).
 
 ## Initramfs
-This is the rescue shell that boots your Linux installer/installation. I'll be using one only, and it's going to be the one that was originally created for PSXITARCH, a distro based on Arch made by the PS3ITA Forums. [Here it is](https://github.com/DionKill/ps4-linux-tutorial/blob/main/PS4%20Linux/initramfs.zip). [Source (not really)](https://bitbucket.org/piotrkarbowski/better-initramfs/src/master/).
+This is the rescue shell that boots your Linux installer/installation. We'll be using [this one](https://github.com/DionKill/ps4-linux-tutorial/blob/main/PS4%20Linux/initramfs.zip). [Source (not really)](https://bitbucket.org/piotrkarbowski/better-initramfs/src/master/).
 
-There's another in-dev initramfs, if you want to check it out it's [here](https://github.com/ps4gentoo/initramfs).
+::: details More stuff
+There's another in-dev initramfs (probably not working), if you want to check out the source it's [here](https://github.com/ps4gentoo/initramfs).
 
-Also, you may want to read [this post](https://ps4linux.com/forums/d/93-tutorial-for-building-a-custom-initramfs-research-development) on the PS4 Linux forums, I found it and thought was really interesting.
-
+Also, you may want to read [this post](https://ps4linux.com/forums/d/93-tutorial-for-building-a-custom-initramfs-research-development) on the PS4 Linux forums, it explains what an initramfs is and does in actuality.
+:::
 ## Distros (that you ACTUALLY wanna use)
 Yes! Finally the time has come. Which one will you choose?
-Honestly there's a neptillion distros. Most however, are very outdated, especially the ones on the PS4Linux's website list.
+Honestly there's a neptillion distros... Choose one that you may like, or distro hop a bunch!
 
-These distros are newer, supported by updates and recommended. CachyOS was used for this guide, but you can follow the same method of installation for all the other ones reported here.
-
-| Distro                                                                                               | Base           | Port credits                                                              | Info                                                                                |
-| ---------------------------------------------------------------------------------------------------- | -------------- | ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| [CachyOS](https://mega.nz/file/RyUVQARB#HZD49XXac_v2CYKD4Oqa7Tg1aiZ7ltH_cnDxixw9JjY)                 | Arch           | [Elokuba (Qba)](https://www.youtube.com/channel/UCU-eXjZ7Ud0k2wC_14mqdOw) | "Final Fantasy v2" version. It has nothing to do with FF.                           |
-| [EndeavourOS](https://ps4linux.com/forums/d/386-endeavouros-gaming-rebirth)                          | Arch           | [Elokuba (Qba)](https://www.youtube.com/channel/UCU-eXjZ7Ud0k2wC_14mqdOw) | Arch based distro that's nice to use and easy to maintain                           |
-| [Manjaro](https://ps4linux.com/forums/d/342-manjaro-from-scratch)                                    | Arch           | [Elokuba (Qba)](https://www.youtube.com/channel/UCU-eXjZ7Ud0k2wC_14mqdOw) | A Manjaro KDE distro                                                                |
-| [Garuda](https://ps4linux.com/forums/d/415-garuda-dr460nized-gaming-v2/2)                            | Arch           | [Elokuba (Qba)](https://www.youtube.com/channel/UCU-eXjZ7Ud0k2wC_14mqdOw) | "Gaming focused" distro (not really)                                                |
-| [Fedora 42](https://ps4linux.com/forums/d/399-fedora42-by-qba-triki1kdewayland)                      | Fedora         | [Elokuba (Qba)](https://www.youtube.com/channel/UCU-eXjZ7Ud0k2wC_14mqdOw) | Normal Fedora running KDE on Wayland                                                |
-| [Debian Forky](https://ps4linux.com/forums/d/373-debian-forky-sid/3)                                 | Debian         | [triki1](https://www.youtube.com/@trakerchris9876)                        | Very new distro. Extremely bleeding edge.                                           |
-| [Kali Linux](https://ps4linux.com/forums/d/392-debian-forky-kali-linux-edition)                      | Debian         | [triki1](https://www.youtube.com/@trakerchris9876)                        | Based on Debian Forky, but with Kali Linux stuff included                           |
-| [Debian Trixie](https://ps4linux.com/forums/d/369-debien-trixie-full-update-mesa-2520-devel/13)      | Debian         | [triki1](https://www.youtube.com/@trakerchris9876)                        | Latest Debian                                                                       |
-| [Xubuntu](https://ps4linux.com/forums/d/337-xubuntu-2504-final-release)                              | Ubuntu         | [triki1](https://www.youtube.com/@trakerchris9876)                        | Divided into multiple files                                                         |
-| [Arch](https://ps4linux.com/forums/d/413-archlinux-minimal)                                          | Arch           | [centi07](https://github.com/centi07)                                     | A basic Arch install                                                                |
-| [Arch + TempleOS](https://github.com/ErkkolaMaitohappo/arch-ps4-aur-smth-fork/releases/tag/v1%2Bkde) | Arch, TempleOS | [Erkkola](https://github.com/ErkkolaMaitohappo)                           | Basic Arch + TempleOS, for the memes!                                               |
-| [Batocera 40](https://ps4linux.com/forums/d/252-batocera-40-for-ps4-installation-setup-tutorial)     | No clue        | [Noob404](https://www.youtube.com/channel/UC9pY5BDCjDLOC4j-zkHPu8)        | For retrogaming                                                                     |
-| [JaguarLinux](https://ps4linux.com/forums/d/265-jaguarlinux-a-ps4-linux-only-distro-beta-release/3)  | None           | [TigerClips1](https://github.com/TigerClips1/)                            | A distro made from scratch for the PS4! Still in development, but worth mentioning. |
+| Distro                                                                                               | Base                            | Port credits                                                              | Info                                                                                |
+| ---------------------------------------------------------------------------------------------------- | ------------------------------- | ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| [CachyOS](https://mega.nz/file/RyUVQARB#HZD49XXac_v2CYKD4Oqa7Tg1aiZ7ltH_cnDxixw9JjY)                 | Arch                            | [Elokuba (Qba)](https://www.youtube.com/channel/UCU-eXjZ7Ud0k2wC_14mqdOw) | "Final Fantasy v2" version. It has nothing to do with FF. Mere fantasy.                          |
+| [EndeavourOS](https://ps4linux.com/forums/d/386-endeavouros-gaming-rebirth)                          | Arch                            | [Elokuba (Qba)](https://www.youtube.com/channel/UCU-eXjZ7Ud0k2wC_14mqdOw) | Arch based distro that's nice to use and easy to maintain                           |
+| [Manjaro](https://ps4linux.com/forums/d/342-manjaro-from-scratch)                                    | Arch                            | [Elokuba (Qba)](https://www.youtube.com/channel/UCU-eXjZ7Ud0k2wC_14mqdOw) | A Manjaro KDE distro                                                                |
+| [Garuda](https://ps4linux.com/forums/d/415-garuda-dr460nized-gaming-v2/2)                            | Arch                            | [Elokuba (Qba)](https://www.youtube.com/channel/UCU-eXjZ7Ud0k2wC_14mqdOw) | "Gaming focused" distro (not really)                                                |
+| [Fedora 42](https://ps4linux.com/forums/d/399-fedora42-by-qba-triki1kdewayland)                      | Fedora                          | [Elokuba (Qba)](https://www.youtube.com/channel/UCU-eXjZ7Ud0k2wC_14mqdOw) | Normal Fedora running KDE on Wayland                                                |
+| [Debian Forky](https://ps4linux.com/forums/d/373-debian-forky-sid/3)                                 | Debian                          | [triki1](https://www.youtube.com/@trakerchris9876)                        | Very new distro. Extremely bleeding edge.                                           |
+| [Kali Linux](https://ps4linux.com/forums/d/392-debian-forky-kali-linux-edition)                      | Debian                          | [triki1](https://www.youtube.com/@trakerchris9876)                        | Based on Debian Forky, but with Kali Linux stuff included                           |
+| [Debian Trixie](https://ps4linux.com/forums/d/369-debien-trixie-full-update-mesa-2520-devel/13)      | Debian                          | [triki1](https://www.youtube.com/@trakerchris9876)                        | Latest Debian                                                                       |
+| [Xubuntu](https://ps4linux.com/forums/d/337-xubuntu-2504-final-release)                              | Ubuntu                          | [triki1](https://www.youtube.com/@trakerchris9876)                        | Divided into multiple files                                                         |
+| [Arch](https://ps4linux.com/forums/d/413-archlinux-minimal)                                          | Arch                            | [centi07](https://github.com/centi07)                                     | A basic Arch install                                                                |
+| [Arch + TempleOS](https://github.com/ErkkolaMaitohappo/arch-ps4-aur-smth-fork/releases/tag/v1%2Bkde) | Arch, TempleOS                  | [Erkkola](https://github.com/ErkkolaMaitohappo)                           | Basic Arch + TempleOS, for the memes!                                               |
+| [Batocera 40](https://ps4linux.com/forums/d/252-batocera-40-for-ps4-installation-setup-tutorial)     | No clue                         | [Noob404](https://www.youtube.com/channel/UC9pY5BDCjDLOC4j-zkHPu8)        | For retrogaming                                                                     |
+| [JaguarLinux](https://ps4linux.com/forums/d/265-jaguarlinux-a-ps4-linux-only-distro-beta-release/3)  | None (includes stuff from Void) | [TigerClips1](https://github.com/TigerClips1/)                            | A distro made from scratch for the PS4! Still in development, but worth mentioning. |
 
 >[!TIP]
 >Want to add more distros? Make an issue and your wish shall be granted.


### PR DESCRIPTION
 Fix wrong kernel info in files.md, update links

    - Clean up PS4 Linux Kernel information tables
    - Specify distinction between 5.15.15 Belize and 5.15.15 Aeolia
    - Mention kernel 5.4 for saya's kernels
    - Final Fantastico
    - Add new link to feeRnt's 6.15.4 kernel (subversion 3) in files section. 
 
 Files changed:
  - docs/files.md
  - docs/it/files.md